### PR TITLE
SCSS changes to content-switcher for radio-button emulation

### DIFF
--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -142,6 +142,70 @@
     .#{$prefix}--content-switcher__icon {
     fill: $inverse-01;
   }
+
+  .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected { 
+    background-color: transparent; 
+    color: inherit; 
+  }
+
+  .#{$prefix}--content-switcher-btn INPUT[type="radio"] { 
+    opacity: 0; 
+    position: fixed; 
+    width: 0; 
+    height: rem(16px); 
+    left: rem(16px); 
+  }
+
+  .#{$prefix}--content-switcher-btn INPUT[type="radio"]:checked 
+    + .#{$prefix}--content-switcher__label { 
+    background-color: $ui-05; 
+    color: $inverse-01; 
+  }
+
+  .#{$prefix}--content-switcher-btn { 
+    padding: 0; 
+  }
+
+  .#{$prefix}--content-switcher__label { 
+    height:100%; 
+    width: 100%; 
+    padding: $carbon--spacing-03 $carbon--spacing-05; 
+    line-height: 1.6; 
+    margin-bottom: 0; 
+  }
+
+  .#{$prefix}--content-switcher__label:hover { 
+    cursor: pointer; 
+  }
+
+  .#{$prefix}--content-switcher-btn INPUT[type="radio"]:focus 
+    + .#{$prefix}--content-switcher__label { 
+    box-shadow: inset 0 0 0 2px $focus; 
+  }
+
+  .#{$prefix}--content-switcher-btn:not(:first-of-type)::before { 
+    background-color: transparent; 
+  }
+
+  .#{$prefix}--content-switcher-btn:not(:first-of-type) 
+    .#{$prefix}--content-switcher__label::before { 
+    content: ''; 
+    display: block; 
+    height: rem(16px); 
+    width: rem(1px); 
+    background-color: $content-switcher-divider; 
+    position: absolute; 
+    z-index: 2; 
+    left: 0; 
+    top: rem(12px); 
+  }
+
+  .#{$prefix}--content-switcher-btn:not(:first-of-type) INPUT[type="radio"]:checked 
+    + .#{$prefix}--content-switcher__label::before,
+  .#{$prefix}--content-switcher-btn:not(:first-of-type) INPUT[type="radio"]:focus 
+    + .#{$prefix}--content-switcher__label::before { 
+    background-color: transparent; 
+  }
 }
 
 @include exports('content-switcher') {

--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -128,8 +128,8 @@
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected {
-    background-color: $ui-05;
-    color: $inverse-01;
+    background-color: transparent;
+    color: inherit;
     z-index: 3;
 
     &:disabled {
@@ -141,11 +141,6 @@
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected
     .#{$prefix}--content-switcher__icon {
     fill: $inverse-01;
-  }
-
-  .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected { 
-    background-color: transparent; 
-    color: inherit; 
   }
 
   .#{$prefix}--content-switcher-btn INPUT[type="radio"] { 

--- a/packages/components/src/components/content-switcher/content-switcher.hbs
+++ b/packages/components/src/components/content-switcher/content-switcher.hbs
@@ -7,12 +7,9 @@
 
 <div data-content-switcher class="{{@root.prefix}}--content-switcher" role="tablist" aria-label="Demo switch content">
   {{#each items}}
-  <button class="{{@root.prefix}}--content-switcher-btn{{#if selected}} {{@root.prefix}}--content-switcher--selected{{/if}}"
-    data-target="{{target}}" role="tab" {{#if selected}} aria-selected="true" {{/if}} {{#if disabled}} disabled {{/if}}>
-    {{#if ../hasIcon}}
-      {{ carbon-icon 'AddFilled16' class=(add @root.prefix '--content-switcher__icon') }}
-    {{/if}}
-    {{#if label}}<span class={{@root.prefix}}--content-switcher__label>{{label}}</span>{{/if}}
-  </button>
+  <div class="{{@root.prefix}}--content-switcher-btn" role="presentation">
+    <input type="radio" id="{{id}}" name="{{../group}}" value="{{value}}" tabindex="0" role="radio"{{#if selected}} checked{{/if}}{{#if disabled}} disabled{{/if}}>
+    <label for="{{id}}" class="{{@root.prefix}}--content-switcher__label">{{label}}</label>
+  </div>
   {{/each}}
 </div>

--- a/packages/components/src/components/content-switcher/content-switcher.js
+++ b/packages/components/src/components/content-switcher/content-switcher.js
@@ -41,18 +41,18 @@ class ContentSwitcher extends mixin(
   constructor(element, options) {
     super(element, options);
     this.manage(
-      on(this.element, 'click', event => {
-        this._handleClick(event);
+      on(this.element, 'change', event => {
+        this._handleChange(event);
       })
     );
   }
 
   /**
-   * Handles click on content switcher button set.
+   * Handles change action on content switcher button set.
    * If the click is on a content switcher button, activates it.
    * @param {Event} event The event triggering this method.
    */
-  _handleClick(event) {
+  _handleChange(event) {
     const button = eventMatches(event, this.options.selectorButton);
 
     if (button) {
@@ -91,7 +91,6 @@ class ContentSwitcher extends mixin(
 
     selectorButtons.forEach(button => {
       if (button !== item) {
-        button.setAttribute('aria-selected', false);
         button.classList.toggle(this.options.classActive, false);
         toArray(
           button.ownerDocument.querySelectorAll(button.dataset.target)
@@ -103,7 +102,7 @@ class ContentSwitcher extends mixin(
     });
 
     item.classList.toggle(this.options.classActive, true);
-    item.setAttribute('aria-selected', true);
+    item.checked = true;
     toArray(item.ownerDocument.querySelectorAll(item.dataset.target)).forEach(
       element => {
         element.removeAttribute('hidden');


### PR DESCRIPTION
**New**

- Enhance content-switcher to make it more AVT compliant by using radio buttons to perform the switch of the content.

**Changed**

- SCSS changes included - html changes forthcoming

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
